### PR TITLE
Updates middleware register call to work with Faraday 0.9.

### DIFF
--- a/lib/faraday/digestauth.rb
+++ b/lib/faraday/digestauth.rb
@@ -93,4 +93,8 @@ module Faraday
 end
 
 # Register the middleware as a Request middleware with the name :digest
-Faraday.register_middleware :request, digest: Faraday::Request::DigestAuth
+if Faraday.respond_to?(:register_middleware)
+  Faraday.register_middleware :request, :digest => Faraday::Request::DigestAuth
+else
+  Faraday::Request.register_middleware :digest => Faraday::Request::DigestAuth
+end


### PR DESCRIPTION
Keeping support for Faraday 0.8 as well, and tweaking existing hash syntax to hash-rockets so this gem works with MRI 1.8 too.
