### PR TITLE
RuboCop fails when running specs due to parallel assignment

### DIFF
--- a/lib/faraday/request/digestauth.rb
+++ b/lib/faraday/request/digestauth.rb
@@ -31,7 +31,8 @@ module Faraday
       #              the original request body
       def initialize(app, user, password, opts = {})
         super(app)
-        @user, @password = user, password
+        @user = user
+        @password = password
         @opts = opts
       end
 


### PR DESCRIPTION
Fixing this issue:

Warning: unrecognized cop Blocks found in /Users/navidkamali/.rvm/gems/ruby-1.9.3-p125@snap-yosemite/gems/faraday-digestauth-0.2.1/.rubocop.yml
Inspecting 9 files
......C..

Offenses:

lib/faraday/request/digestauth.rb:34:9: C: Do not use parallel assignment.
        @user, @password = user, password
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

9 files inspected, 1 offense detected
RuboCop failed!