### PR TITLE
Escape user and password

### DIFF
--- a/lib/faraday/request/digestauth.rb
+++ b/lib/faraday/request/digestauth.rb
@@ -71,8 +71,8 @@ module Faraday
       # Returns a String with the DigestAuth header.
       def header(response)
         uri = response.env[:url]
-        uri.user = @user
-        uri.password = @password
+        uri.user = CGI.escape @user
+        uri.password = CGI.escape @password
 
         realm = response.headers['www-authenticate']
         method = response.env[:method].to_s.upcase


### PR DESCRIPTION
Must escape `uri.user` and `uri.password` otherwise may get `URI::InvalidComponentError`.
