### PR TITLE
Only perform digest authentication if the server supports it

### DIFF
--- a/lib/faraday/request/digestauth.rb
+++ b/lib/faraday/request/digestauth.rb
@@ -46,6 +46,7 @@ module Faraday
       def call(env)
         response = handshake(env)
         return response unless response.status == 401
+        return response unless response.headers['www-authenticate'] =~ /Digest +[^\s]+/
 
         env[:request_headers]['Authorization'] = header(response)
         @app.call(env)

--- a/spec/faraday-digestauth_spec.rb
+++ b/spec/faraday-digestauth_spec.rb
@@ -18,7 +18,20 @@ describe Faraday::Request::DigestAuth do
     end
   end
 
-  describe 'when the server returns a 401' do
+  describe 'when the server returns a 401 without a digest authentication scheme' do
+    let(:first_call_headers) { 'Basic realm="MyApp"' }
+    it 'does nothing' do
+      stub_request(:get, 'http://api.example.org/productions/1')
+        .with(body: nil)
+        .to_return(status: 401, headers: { 'www-authenticate' => first_call_headers })
+
+      response = connection.get('/productions/1')
+      expect(response.status).to eq 401
+      expect(response.body).to be_empty
+    end
+  end
+
+  describe 'when the server returns a 401 with a digest authentication scheme' do
     let(:first_call_headers) { 'Digest realm="MyApp", algorithm=MD5' }
     let(:second_call_headers) { 'Digest username="USER", realm="MyApp", uri="/", algorithm="MD5"' }
     it 'authenticates using digest' do


### PR DESCRIPTION
The middleware should only act if the server mentions the digest authentications scheme in the WWW-Authenticate header. Without checking the header, the middleware offers the header to the
Net::HTTP::Digest library which cannot handle it and it crashes.

Parsing/regexps for the header are inspired by RFC 2617: https://tools.ietf.org/html/rfc2617#section-3.2.1.