### PR TITLE
Relax Faraday dependency constraints

### DIFF
--- a/faraday-digestauth.gemspec
+++ b/faraday-digestauth.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 0.7'
+  spec.add_dependency 'faraday', '>= 0.7'
   spec.add_dependency 'net-http-digest_auth', '~> 1.4'
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'coveralls', '~> 0.1'


### PR DESCRIPTION
There will be a new [Faraday version `1.0.0` coming up soon](https://github.com/lostisland/faraday/blob/v1.0-rc1/UPGRADING.md#faraday-10) and I'd like to test `faraday-digestauth` with [`1.0.0.pre.rc1`](https://rubygems.org/gems/faraday/versions/1.0.0.pre.rc1).