### PR TITLE
Remove Content-Length after handshake

### DIFF
--- a/lib/faraday/request/digestauth.rb
+++ b/lib/faraday/request/digestauth.rb
@@ -47,7 +47,7 @@ module Faraday
         response = handshake(env)
         return response unless response.status == 401
         return response unless response.headers['www-authenticate'] =~ /Digest +[^\s]+/
-
+        env[:request_headers].delete("Content-Length")
         env[:request_headers]['Authorization'] = header(response)
         @app.call(env)
       end


### PR DESCRIPTION
I was using this gem for digest auth and noticed that when I used Typhoeus adapter, I got the following response:

```json
{
  "http_status": 422,
  "error": {
    "message": "invalid data format/type",
    "description": "Problems parsing request as json",
    "code": "1300"
  },
  "results": { }
}
```

I didn't have this error with other adapters and after some debugging realized that the issue was with the `Content-Length` set to 0.