### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Ruby CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version: [3.1, "3.0", 2.7, 2.6]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run tests
+        run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-
-rvm:
-  - 2.6.6

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Faraday::DigestAuth
 
 [![Gem Version](https://badge.fury.io/rb/faraday-digestauth.svg)](https://badge.fury.io/rb/faraday-digestauth)
-[![Build Status](https://travis-ci.org/bhaberer/faraday-digestauth.svg?branch=master)](https://travis-ci.org/bhaberer/faraday-digestauth)
 [![Coverage Status](https://coveralls.io/repos/bhaberer/faraday-digestauth/badge.svg?branch=master)](https://coveralls.io/r/bhaberer/faraday-digestauth?branch=master)
 [![Code Climate](https://codeclimate.com/github/bhaberer/faraday-digestauth.svg)](https://codeclimate.com/github/bhaberer/faraday-digestauth)
 


### PR DESCRIPTION
This PR adds a conventional CI config for GitHub Actions.

The Travis CI seems to have stopped building.

- add CI config
- drop old CI config
- drop old CI build status badge from README