### PR TITLE
test: Avoid deprecation warning in simplecov

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,12 @@
 require 'coveralls'
 require 'simplecov'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
+)
 SimpleCov.start
 
 require 'faraday/digestauth'


### PR DESCRIPTION
The warning said to use `.new` instead of `#[]`. Done!

~~(The wonky indent: that was RuboCop.)~~ **Update**: Made it pass the linter.