### PR TITLE
chore: Drop unused directives in gemspec

### DIFF
--- a/faraday-digestauth.gemspec
+++ b/faraday-digestauth.gemspec
@@ -15,8 +15,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ['lib']
 
   spec.add_dependency 'faraday', '>= 0.7'


### PR DESCRIPTION
The test_files directive is not used by RubyGems, but this starts by
making it only refer to directories that are actually in this repo.

The executables directive is unused - this gem exposes no executables.