### PR TITLE
Faraday 2 support (update CI and dependencies)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,16 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      FARADAY_VERSION: ${{ matrix.faraday-version }}
+
     strategy:
       matrix:
-        ruby-version: [3.1, "3.0", 2.7, 2.6]
+        ruby-version: ['3.0', 3.1, 3.2, 3.3]
+        faraday-version: ['~> 1.0', '~> 2.0']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
 require: rubocop-rspec
 
 AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  TargetRubyVersion: 3.0
+  SuggestExtensions: false
   Exclude:
     - vendor/**/*
     - bin/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,10 @@ install_if -> { ENV.fetch('FARADAY_VERSION', nil) } do
 end
 
 gem 'coveralls', '~> 0.1'
-gem 'rake', '~> 12.3.3'
+gem 'rake', '~> 12.3'
 gem 'rspec', '~> 3'
-gem 'rubocop', '0.82.0'
-gem 'rubocop-rspec', '1.39.0'
-gem 'webmock', '~> 3.8.3'
+gem 'rubocop', '~> 1.62'
+gem 'rubocop-packaging', '~> 0.5'
+gem 'rubocop-performance', '~> 1.20'
+gem 'rubocop-rspec', '~> 2.27'
+gem 'webmock', '~> 3.23'

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,14 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in faraday-digestauth.gemspec
 gemspec
+
+install_if -> { ENV.fetch('FARADAY_VERSION', nil) } do
+  gem 'faraday', ENV.fetch('FARADAY_VERSION', nil)
+end
+
+gem 'coveralls', '~> 0.1'
+gem 'rake', '~> 12.3.3'
+gem 'rspec', '~> 3'
+gem 'rubocop', '0.82.0'
+gem 'rubocop-rspec', '1.39.0'
+gem 'webmock', '~> 3.8.3'

--- a/faraday-digestauth.gemspec
+++ b/faraday-digestauth.gemspec
@@ -21,10 +21,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '>= 0.7'
   spec.add_dependency 'net-http-digest_auth', '~> 1.4'
-  spec.add_development_dependency 'coveralls', '~> 0.1'
-  spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rspec', '~> 3'
-  spec.add_development_dependency 'rubocop', '0.82.0'
-  spec.add_development_dependency 'rubocop-rspec', '1.39.0'
-  spec.add_development_dependency 'webmock', '~> 3.8.3'
 end

--- a/faraday-digestauth.gemspec
+++ b/faraday-digestauth.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 3.0', '< 4'
+
   spec.add_dependency 'faraday', '>= 0.7'
   spec.add_dependency 'net-http-digest_auth', '~> 1.4'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,12 @@
 require 'coveralls'
 require 'simplecov'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
+)
 SimpleCov.start
 
 require 'faraday/digestauth'


### PR DESCRIPTION
## Summary

This PR refreshes outdated development dependencies and more notably sets Ruby 3.0 as the minimum Ruby version (this will likely warrant a new major release). The reason is that Ruby 3.0 is nearing EOL already, and Faraday 2.0 does not support Ruby 2.7 or earlier.

CI has also been improved to test the correct Ruby versions, as well as adding a dimension to test both Faraday 1.x and 2.x